### PR TITLE
Remove script tags from the rendered html

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const server = prerender({
 
 server.use(require('prerender-request-blacklist'));
 server.use(prerender.blacklist());
+server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
-
 server.start();
 


### PR DESCRIPTION
This will remove the script tags from the html, which are not needed for the bots as the HTML is already rendered. E.g. bot doesn't need angular bundle files, once the prerender has created the html.