### PR TITLE
Add `--disable-dev-shm-usage` To Chrome Flags

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const prerender = require('prerender');
 const server = prerender({
-  chromeFlags: [ '--no-sandbox', '--headless', '--disable-gpu', '--remote-debugging-port=9222', '--hide-scrollbars' ],
+  chromeFlags: [ '--no-sandbox', '--headless', '--disable-gpu', '--remote-debugging-port=9222', '--hide-scrollbars', '--disable-dev-shm-usage' ],
   forwardHeaders: true,
   chromeLocation: '/usr/bin/chromium-browser'
 });


### PR DESCRIPTION
This fixes some issues with running chrome inside of Docker containers: https://github.com/prerender/prerender/issues/524#issuecomment-420193007.

So far it seems to be helping prevent some 503's that I was getting from Prerender when I was hosting it.

BTW thanks for the nifty little container that was so easy to code review for lack of lines of code. :wink: