### PR TITLE
Add tini as init process and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,12 @@ ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/
 ENV MEMORY_CACHE=0
 
-ENV UNAME=prerender
-ENV UID=1001
-ENV GID=1001
-
 # install chromium, tini and clear cache
 RUN apk add --update-cache chromium tini \
  && rm -rf /var/cache/apk/* /tmp/*
 
-RUN addgroup --gid "$GID" "$UNAME" && \
-    adduser --disabled-password --gecos "" --ingroup "$UNAME" --uid "$UID" "$UNAME"
-
-USER $UNAME
-WORKDIR "/home/$UNAME"
+USER node
+WORKDIR "/home/node"
 
 COPY ./package.json .
 COPY ./server.js .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,22 @@ ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/
 ENV MEMORY_CACHE=0
 
-WORKDIR /home/node
-
-COPY ./package.json .
-COPY ./server.js .
+ENV UNAME=prerender
+ENV UID=1001
+ENV GID=1001
 
 # install chromium, tini and clear cache
 RUN apk add --update-cache chromium tini \
  && rm -rf /var/cache/apk/* /tmp/*
+
+RUN addgroup --gid "$GID" "$UNAME" && \
+    adduser --disabled-password --gecos "" --ingroup "$UNAME" --uid "$UID" "$UNAME"
+
+USER $UNAME
+WORKDIR "/home/$UNAME"
+
+COPY ./package.json .
+COPY ./server.js .
 
 # install npm packages
 RUN npm install --no-package-lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:14-alpine3.12
+
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/
 ENV MEMORY_CACHE=0
@@ -8,8 +9,8 @@ WORKDIR /home/node
 COPY ./package.json .
 COPY ./server.js .
 
-# install chromium and clear cache
-RUN apk add --update-cache chromium \
+# install chromium, tini and clear cache
+RUN apk add --update-cache chromium tini \
  && rm -rf /var/cache/apk/* /tmp/*
 
 # install npm packages
@@ -17,4 +18,5 @@ RUN npm install --no-package-lock
 
 EXPOSE 3000
 
+ENTRYPOINT ["tini", "--"]
 CMD ["node", "server.js"]


### PR DESCRIPTION
This PR implements 2 best practices for Docker:
1. Not running `node` with pid 1
2. Not running the process as root


Before:
```
/home/node # pstree
node---chrome-+-2*[chrome---chrome]
              `-chrome
/home/node # ps aux | cat
PID   USER     TIME  COMMAND
    1 root      0:00 node server.js
   16 root      0:00 /usr/lib/chromium/chrome --extra-plugin-dir=/usr/lib/nsbrowser/plugins --user-data-dir=/root/.config/chromium --no-sandbox --headless --disable-gpu --remote-debugging-port=9222 --hide-scrollbars --disable-dev-shm-usage
   21 root      0:00 /usr/lib/chromium/chrome --type=zygote --no-zygote-sandbox --no-sandbox --headless --headless
   22 root      0:00 /usr/lib/chromium/chrome --type=zygote --no-sandbox --headless --headless
   37 root      0:00 /usr/lib/chromium/chrome --type=gpu-process --field-trial-handle=647808687620505925,6407418767020044007,131072 --no-sandbox --disable-dev-shm-usage --headless --headless --gpu-preferences=MAAAAAAAAAAgAAAQAAAAAAAAAAAAAAAAAABgAAAAAAAQAAAAAAAAAAAAAAAAAAAACAAAAAAAAAA= --use-gl=swiftshader-webgl --override-use-software-gl-for-tests --shared-files
   39 root      0:00 /usr/lib/chromium/chrome --type=utility --utility-sub-type=network.mojom.NetworkService --field-trial-handle=647808687620505925,6407418767020044007,131072 --lang=en-US --service-sandbox-type=network --no-sandbox --disable-dev-shm-usage --use-gl=swiftshader-webgl --headless --shared-files=v8_snapshot_data:100
   40 root      0:00 /usr/lib/chromium/chrome --type=renderer --no-sandbox --disable-dev-shm-usage --file-url-path-alias=/gen=/usr/lib/chromium/gen --remote-debugging-port=9222 --allow-pre-commit-input --field-trial-handle=647808687620505925,6407418767020044007,131072 --disable-gpu-compositing --lang=en-US --headless --lang=en-US --num-raster-threads=2 --enable-main-frame-before-activation --renderer-client-id=4 --shared-files=v8_snapshot_data:100
   67 root      0:00 sh
   84 root      0:00 ps aux
   85 root      0:00 cat
```

After:
```
~ $ pstree
tini---node---chrome-+-2*[chrome---chrome]
                     `-chrome
~ $ ps aux | cat
PID   USER     TIME  COMMAND
    1 node      0:00 tini -- node server.js
    7 node      0:00 node server.js
   14 node      0:00 /usr/lib/chromium/chrome --extra-plugin-dir=/usr/lib/nsbrowser/plugins --no-sandbox --headless --disable-gpu --remote-debugging-port=9222 --hide-scrollbars --disable-dev-shm-usage
   18 node      0:00 /usr/lib/chromium/chrome --type=zygote --no-zygote-sandbox --no-sandbox --headless --headless
   19 node      0:00 /usr/lib/chromium/chrome --type=zygote --no-sandbox --headless --headless
   34 node      0:00 /usr/lib/chromium/chrome --type=gpu-process --field-trial-handle=13962301823260715964,12184465221106792076,131072 --no-sandbox --disable-dev-shm-usage --headless --headless --gpu-preferences=MAAAAAAAAAAgAAAQAAAAAAAAAAAAAAAAAABgAAAAAAAQAAAAAAAAAAAAAAAAAAAACAAAAAAAAAA= --use-gl=swiftshader-webgl --override-use-software-gl-for-tests --shared-files
   35 node      0:00 /usr/lib/chromium/chrome --type=utility --utility-sub-type=network.mojom.NetworkService --field-trial-handle=13962301823260715964,12184465221106792076,131072 --lang=en-US --service-sandbox-type=network --no-sandbox --disable-dev-shm-usage --use-gl=swiftshader-webgl --headless --shared-files=v8_snapshot_data:100
   36 node      0:00 /usr/lib/chromium/chrome --type=renderer --no-sandbox --disable-dev-shm-usage --file-url-path-alias=/gen=/usr/lib/chromium/gen --remote-debugging-port=9222 --allow-pre-commit-input --field-trial-handle=13962301823260715964,12184465221106792076,131072 --disable-databases --disable-gpu-compositing --lang=en-US --headless --lang=en-US --num-raster-threads=2 --enable-main-frame-before-activation --renderer-client-id=4 --shared-files=v8_snapshot_data:100
   63 node      0:00 sh
   75 node      0:00 ps aux
   76 node      0:00 cat
```