### PR TITLE
Fix instructions for using custom server.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A few default plugins have been activated by default (see `server.js`):
 This can be modified by creating your own `server.js` and mounting this file as a docker volume:
 
 ```
-docker run -p 3000:3000 -v $(pwd)/server.js:/server.js tvanro/prerender-alpine:6.3.0 
+docker run -p 3000:3000 -v $(pwd)/server.js:/home/node/server.js tvanro/prerender-alpine:6.3.0 
 ```
 
 ## Prerender memory cache


### PR DESCRIPTION
The correct path is `/home/node/server.js` not `/server.js`.